### PR TITLE
Remove install.xml and revert version for compatibility.

### DIFF
--- a/local/facialbiometrics/amd/src/facialbiometrics.js
+++ b/local/facialbiometrics/amd/src/facialbiometrics.js
@@ -1,0 +1,19 @@
+define([], function() {
+    const init = function() {
+        const validateButton = document.getElementById('validateBtn');
+        const validationMessage = document.getElementById('validationMsg');
+
+        if (validateButton && validationMessage) {
+            validateButton.addEventListener('click', function() {
+                validationMessage.style.display = 'block';
+            });
+        } else {
+            // Log an error if elements are not found, for easier debugging.
+            console.error('Facial Biometrics: Button or message element not found.');
+        }
+    };
+
+    return {
+        init: init
+    };
+});

--- a/local/facialbiometrics/db/access.php
+++ b/local/facialbiometrics/db/access.php
@@ -1,0 +1,22 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = array(
+    'local/facialbiometrics:view' => array(
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => array(
+            'user' => CAP_ALLOW, // Added user
+            'manager' => CAP_ALLOW,
+        ),
+    ),
+    'local/facialbiometrics:manage' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+        ),
+    ),
+);
+?>

--- a/local/facialbiometrics/index.php
+++ b/local/facialbiometrics/index.php
@@ -1,0 +1,35 @@
+<?php
+
+require_once(__DIR__ . '/../../config.php');
+
+// Get the language strings for this plugin.
+$pluginstring = function(string $key, $a = null) {
+    return get_string($key, 'local_facialbiometrics', $a);
+};
+
+$PAGE->set_url('/local/facialbiometrics/index.php');
+$PAGE->set_context(context_system::instance()); // Consider context_course if it's course-specific later.
+$PAGE->set_title($pluginstring('pluginname'));
+$PAGE->set_heading($pluginstring('pluginname'));
+
+// Require login to view this page.
+require_login(); // Keep this to ensure user is logged in.
+$context = context_system::instance(); // Get system context.
+require_capability('local/facialbiometrics:view', $context); // Check for the new capability.
+
+echo $OUTPUT->header();
+
+// Button to trigger the validation message.
+echo html_writer::tag('button', $pluginstring('validatebutton'), ['id' => 'validateBtn']);
+
+// Paragraph that will be shown on button click.
+echo html_writer::tag('p', $pluginstring('validationrequested'), ['id' => 'validationMsg', 'style' => 'display:none;']);
+
+// JavaScript to handle the button click.
+$PAGE->requires->js_init_call('M.local_facialbiometrics.init', [], false, [
+    'amd' => true // Assuming we might move this to an AMD module later
+]);
+
+echo $OUTPUT->footer();
+
+?>

--- a/local/facialbiometrics/lang/en/local_facialbiometrics.php
+++ b/local/facialbiometrics/lang/en/local_facialbiometrics.php
@@ -1,0 +1,16 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['pluginname'] = 'Facial Biometrics';
+$string['facialbiometrics'] = 'Facial Biometrics';
+$string['privacy:metadata'] = 'The Facial Biometrics plugin does not store any personal data.';
+$string['apikey'] = 'API Key';
+$string['apikeydesc'] = 'Enter your Facial Biometrics API Key.';
+$string['apisecret'] = 'API Secret';
+$string['apisecretdesc'] = 'Enter your Facial Biometrics API Secret.';
+$string['region'] = 'Region';
+$string['regiondesc'] = 'Select the Azure region for the Facial Biometrics API.';
+$string['validatebutton'] = 'Request Validation';
+$string['validationrequested'] = 'Validation has been requested.';
+?>

--- a/local/facialbiometrics/settings.php
+++ b/local/facialbiometrics/settings.php
@@ -1,0 +1,44 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($hassiteconfig) { // needs this condition or there is error on login page
+    $settings = new admin_settingpage('local_facialbiometrics', get_string('pluginname', 'local_facialbiometrics'));
+    $ADMIN->add('localplugins', $settings);
+
+    // Facial Biometrics API Key
+    $setting = new admin_setting_configtext(
+        'local_facialbiometrics/apikey',
+        get_string('apikey', 'local_facialbiometrics'),
+        get_string('apikeydesc', 'local_facialbiometrics'),
+        '',
+        PARAM_TEXT
+    );
+    $settings->add($setting);
+
+    // Facial Biometrics API Secret
+    $setting = new admin_setting_configpasswordunmask(
+        'local_facialbiometrics/apisecret',
+        get_string('apisecret', 'local_facialbiometrics'),
+        get_string('apisecretdesc', 'local_facialbiometrics'),
+        '',
+        PARAM_TEXT
+    );
+    $settings->add($setting);
+
+    // Facial Biometrics Region
+    $setting = new admin_setting_configselect(
+        'local_facialbiometrics/region',
+        get_string('region', 'local_facialbiometrics'),
+        get_string('regiondesc', 'local_facialbiometrics'),
+        'eastus',
+        array(
+            'westus' => 'West US',
+            'eastus' => 'East US',
+            'westeurope' => 'West Europe',
+            'northeurope' => 'North Europe',
+        )
+    );
+    $settings->add($setting);
+}
+?>

--- a/local/facialbiometrics/version.php
+++ b/local/facialbiometrics/version.php
@@ -1,0 +1,10 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'local_facialbiometrics';
+$plugin->version = 2024051500; // YYYYMMDDHH (This is the release version of the plugin)
+$plugin->requires = 2020110900; // Moodle version - copy this from a core plugin
+$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '0.1 Alpha'; // Human-readable version name
+?>


### PR DESCRIPTION
Based on your feedback, removing install.xml resolves a ddlxmlfileerror during plugin installation in some environments. This commit removes the file and reverts the plugin version to its state before attempting to add a dummy table.

